### PR TITLE
refactor types: alphabetize, update responses to use resource types i…

### DIFF
--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -25,8 +25,8 @@ import { Add } from "@carbon/react/icons";
 import { useTranslation } from "react-i18next";
 import { parseDate, formatDatetime } from "@openmrs/esm-framework";
 import styles from "./prescriptions.scss";
-import { EncounterOrders } from "../types";
-import { useOrders } from "../medication-request/medication-request.resource";
+import { PrescriptionsTableRow } from "../types";
+import { usePrescriptionsTable } from "../medication-request/medication-request.resource";
 import OrderExpanded from "../components/order-expanded.component";
 
 enum TabTypes {
@@ -60,20 +60,17 @@ const PrescriptionTabLists: React.FC = () => {
   const [pageSize, setPageSize] = useState(10);
   const [nextOffSet, setNextOffSet] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
-  const { orders, isError, isLoading, totalOrders } = useOrders(
-    pageSize,
-    nextOffSet,
-    searchTerm
-  );
+  const { prescriptionsTableRows, isError, isLoading, totalOrders } =
+    usePrescriptionsTable(pageSize, nextOffSet, searchTerm);
   const encounterToPatientMap = {};
 
   useEffect(() => {
-    if (orders?.length > 0) {
-      orders.map((order: EncounterOrders) => {
+    if (prescriptionsTableRows?.length > 0) {
+      prescriptionsTableRows.map((order: PrescriptionsTableRow) => {
         encounterToPatientMap[order.id] = order.patientUuid;
       });
     }
-  }, [orders]);
+  }, [prescriptionsTableRows]);
 
   return (
     <main className={`omrs-main-content ${styles.prescriptionListContainer}`}>
@@ -124,9 +121,13 @@ const PrescriptionTabLists: React.FC = () => {
               <div className={styles.patientListTableContainer}>
                 {isLoading && <DataTableSkeleton role="progressbar" />}
                 {isError && <p>Error</p>}
-                {orders && (
+                {prescriptionsTableRows && (
                   <>
-                    <DataTable rows={orders} headers={columns} isSortable>
+                    <DataTable
+                      rows={prescriptionsTableRows}
+                      headers={columns}
+                      isSortable
+                    >
                       {({
                         rows,
                         headers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,288 +1,5 @@
 import { OpenmrsResource } from "@openmrs/esm-api";
 
-export interface DrugOrders {
-  id: string;
-  display: string;
-  description: string;
-}
-
-export interface Order {
-  uuid: string;
-  action: string;
-  asNeeded: boolean;
-  asNeededCondition?: string;
-  autoExpireDate: Date;
-  brandName?: string;
-  careSetting: OpenmrsResource;
-  commentToFulfiller: string;
-  dateActivated: Date;
-  dateStopped?: Date | null;
-  dispenseAsWritten: boolean;
-  dose: number;
-  doseUnits: OpenmrsResource;
-  dosingInstructions: string | null;
-  dosingType?:
-    | "org.openmrs.FreeTextDosingInstructions"
-    | "org.openmrs.SimpleDosingInstructions";
-  drug: Drug;
-  duration: number;
-  durationUnits: OpenmrsResource;
-  encounter: OpenmrsResource;
-  frequency: OpenmrsResource;
-  instructions?: string | null;
-  numRefills: number;
-  orderNumber: string;
-  orderReason: string | null;
-  orderReasonNonCoded: string | null;
-  orderType: {
-    conceptClasses: Array<any>;
-    description: string;
-    display: string;
-    name: string;
-    parent: string | null;
-    retired: boolean;
-    uuid: string;
-  };
-  orderer: {
-    display: string;
-    person: {
-      display: string;
-    };
-    uuid: string;
-  };
-  patient: OpenmrsResource;
-  previousOrder: { uuid: string; type: string; display: string } | null;
-  quantity: number;
-  quantityUnits: OpenmrsResource;
-  route: OpenmrsResource;
-  scheduleDate: null;
-  urgency: string;
-}
-
-export interface Drug {
-  uuid: string;
-  name: string;
-  strength: string;
-  concept: OpenmrsResource;
-  dosageForm: OpenmrsResource;
-}
-
-export interface Patient {
-  uuid: string;
-  display: string;
-  identifiers: Array<any>;
-  person: Person;
-}
-
-export interface Person {
-  age: number;
-  attributes: Array<Attribute>;
-  birthDate: string;
-  gender: string;
-  display: string;
-  preferredAddress: OpenmrsResource;
-  uuid: string;
-}
-
-export interface Attribute {
-  attributeType: OpenmrsResource;
-  display: string;
-  uuid: string;
-  value: string | number;
-}
-
-export interface MedicationRequestResponse {
-  resourceType: string;
-  id: string;
-  meta: {
-    lastUpdated: string;
-  };
-  type: string;
-  total: number;
-  entry: Array<{
-    resource: MedicationRequest | MedicationDispense;
-  }>;
-}
-
-export interface Coding {
-  system?: string;
-  code: string;
-  display: string;
-}
-
-export interface CodingArray {
-  [index: number]: Coding;
-}
-
-export interface MedicationRequest {
-  resourceType: string;
-  id: string;
-  meta: {
-    lastUpdated: string;
-  };
-  status: string;
-  intent: string;
-  priority: string;
-  medicationReference: {
-    reference: string;
-    type: string;
-    display: string;
-  };
-  medicationCodeableConcept?: {
-    coding: CodingArray;
-    text: string;
-  };
-  subject: {
-    reference: string;
-    type: string;
-    display: string;
-  };
-  encounter: {
-    reference: string;
-    type: string;
-  };
-  requester: {
-    reference: string;
-    type: string;
-    identifier: {
-      value: string;
-    };
-    display: string;
-  };
-  dosageInstruction: Array<DosageInstruction>;
-  dispenseRequest: {
-    numberOfRepeatsAllowed: number;
-    quantity: {
-      value: number;
-      unit: string;
-      code: string;
-    };
-  };
-}
-
-export interface DosageInstruction {
-  text: string;
-  timing: {
-    repeat: {
-      duration: number;
-      durationUnit: string;
-    };
-    code: {
-      coding: [
-        {
-          code: string;
-          display: string;
-        }
-      ];
-      text: string;
-    };
-  };
-  asNeededBoolean: boolean;
-  route: {
-    coding: [
-      {
-        code: string;
-        display: string;
-      }
-    ];
-    text: string;
-  };
-  doseAndRate: Array<{
-    doseQuantity: {
-      value: number;
-      unit: string;
-      code: string;
-    };
-  }>;
-}
-
-// TODO change this so resource is Encounter | MedicationRequest | MedicationDispense ?
-export interface EncountersWithMedicationRequestsAndMedicationDispensesResponse {
-  resourceType: string;
-  id: string;
-  meta: {
-    lastUpdated: string;
-  };
-  type: string;
-  total: number;
-  entry: Array<{
-    resource: EncounterWithMedicationRequestsAndMedicationDispenses;
-  }>;
-}
-
-export interface EncounterWithMedicationRequestsAndMedicationDispenses {
-  type: string;
-  id: string;
-  resourceType: string;
-  period?: {
-    start: string;
-  };
-  encounter: {
-    reference: string;
-  };
-  subject: {
-    type: string;
-    display: string;
-    reference: string;
-  };
-  medicationReference?: {
-    reference: string;
-    type: string;
-    display: string;
-  };
-  medicationCodeableConcept?: {
-    coding: CodingArray;
-    text: string;
-  };
-  requester: {
-    type: string;
-    display: string;
-    reference: string;
-  };
-  authorizingPrescription?: {
-    reference: string;
-  };
-
-  status: string;
-}
-
-// TODO flesh this out
-export interface Encounter {
-  resourceType: string;
-  id: string;
-  meta: {
-    lastUpdated: string;
-  };
-  period?: {
-    start: string;
-  };
-}
-
-// represents a row in the main table
-export interface EncounterOrders {
-  id: string;
-  created: string;
-  patientName: string;
-  prescriber: string;
-  drugs: string;
-  lastDispenser: string;
-  status: string;
-  patientUuid: string;
-}
-
-export interface AllergyIntoleranceResponse {
-  resourceType: string;
-  id: string;
-  meta: {
-    lastUpdated: string;
-  };
-  type: string;
-  total: number;
-  entry: Array<{
-    resource: AllergyIntolerance;
-  }>;
-}
-
 export interface AllergyIntolerance {
   resourceType: string;
   id: string;
@@ -359,17 +76,112 @@ export interface AllergyIntolerance {
   ];
 }
 
+export interface AllergyIntoleranceResponse {
+  resourceType: string;
+  id: string;
+  meta: {
+    lastUpdated: string;
+  };
+  type: string;
+  total: number;
+  entry: Array<{
+    resource: AllergyIntolerance;
+  }>;
+}
+
+export interface Attribute {
+  attributeType: OpenmrsResource;
+  display: string;
+  uuid: string;
+  value: string | number;
+}
+
+export interface Coding {
+  system?: string;
+  code: string;
+  display: string;
+}
+
+export interface CodingArray {
+  [index: number]: Coding;
+}
+
 export interface CommonConfigProps {
   uuid: string;
   display: string;
 }
 
-export interface OrderConfig {
-  drugRoutes: Array<CommonConfigProps>;
-  drugDosingUnits: Array<CommonConfigProps>;
-  drugDispensingUnits: Array<CommonConfigProps>;
-  durationUnits: Array<CommonConfigProps>;
-  orderFrequencies: Array<CommonConfigProps>;
+export interface DosageInstruction {
+  text: string;
+  timing: {
+    repeat: {
+      duration: number;
+      durationUnit: string;
+    };
+    code: {
+      coding: [
+        {
+          code: string;
+          display: string;
+        }
+      ];
+      text: string;
+    };
+  };
+  asNeededBoolean: boolean;
+  route: {
+    coding: [
+      {
+        code: string;
+        display: string;
+      }
+    ];
+    text: string;
+  };
+  doseAndRate: Array<{
+    doseQuantity: {
+      value: number;
+      unit: string;
+      code: string;
+    };
+  }>;
+}
+
+export interface Drug {
+  uuid: string;
+  name: string;
+  strength: string;
+  concept: OpenmrsResource;
+  dosageForm: OpenmrsResource;
+}
+
+// add more properties, or fine just to keep the ones we are using
+export interface Encounter {
+  resourceType: string;
+  id: string;
+  meta: {
+    lastUpdated: string;
+  };
+  period?: {
+    start: string;
+  };
+  subject?: {
+    reference: string;
+    display: string;
+  };
+}
+
+export interface EncounterResponse {
+  resourceType: string;
+  id: string;
+  meta: {
+    lastUpdated: string;
+  };
+  type: string;
+  total: number;
+  entry: Array<{
+    resource: Encounter | MedicationRequest | MedicationDispense;
+  }>;
 }
 
 export interface MedicationDispense {
@@ -381,6 +193,9 @@ export interface MedicationDispense {
   status: string;
   intent: string;
   priority: string;
+  authorizingPrescription?: {
+    reference: string;
+  };
   medicationReference: {
     reference: string;
     type: string;
@@ -430,4 +245,100 @@ export interface MedicationDispense {
   substitution: {
     wasSubstituted: boolean;
   };
+}
+
+export interface MedicationRequest {
+  resourceType: string;
+  id: string;
+  meta: {
+    lastUpdated: string;
+  };
+  status: string;
+  intent: string;
+  priority: string;
+  medicationReference: {
+    reference: string;
+    type: string;
+    display: string;
+  };
+  medicationCodeableConcept?: {
+    coding: CodingArray;
+    text: string;
+  };
+  subject: {
+    reference: string;
+    type: string;
+    display: string;
+  };
+  encounter: {
+    reference: string;
+    type: string;
+  };
+  requester: {
+    reference: string;
+    type: string;
+    identifier: {
+      value: string;
+    };
+    display: string;
+  };
+  dosageInstruction: Array<DosageInstruction>;
+  dispenseRequest: {
+    numberOfRepeatsAllowed: number;
+    quantity: {
+      value: number;
+      unit: string;
+      code: string;
+    };
+  };
+}
+
+export interface MedicationRequestResponse {
+  resourceType: string;
+  id: string;
+  meta: {
+    lastUpdated: string;
+  };
+  type: string;
+  total: number;
+  entry: Array<{
+    resource: MedicationRequest | MedicationDispense;
+  }>;
+}
+
+export interface OrderConfig {
+  drugRoutes: Array<CommonConfigProps>;
+  drugDosingUnits: Array<CommonConfigProps>;
+  drugDispensingUnits: Array<CommonConfigProps>;
+  durationUnits: Array<CommonConfigProps>;
+  orderFrequencies: Array<CommonConfigProps>;
+}
+
+export interface Patient {
+  uuid: string;
+  display: string;
+  identifiers: Array<any>;
+  person: Person;
+}
+
+export interface Person {
+  age: number;
+  attributes: Array<Attribute>;
+  birthDate: string;
+  gender: string;
+  display: string;
+  preferredAddress: OpenmrsResource;
+  uuid: string;
+}
+
+// represents a row in the main table
+export interface PrescriptionsTableRow {
+  id: string;
+  created: string;
+  patientName: string;
+  prescriber: string;
+  drugs: string;
+  lastDispenser: string;
+  status: string;
+  patientUuid: string;
 }


### PR DESCRIPTION
…nstead of duplicating fields, rename "orders" to "medicationRequests"; rename "EncounterOrders" to prescription table

@pirupius  this is the beginning of some of the refactoring was looking to do, decided it was best to take it in small chunks.  Key things I did:

* sorted all the types in types.ts alphabetically
* removed some types that didn't appear to be used
* simplified the "Response" types so that they used the Encounter, MedicationRequest and MedicationDispense types instead of duplicating fields
* tried to remove the term "order" and replace with "medicationrequest" in an attempt for better clarity ("order" is the name in OpenMRS, "medication request" is the name in FHIR, seems best to try to stick to using one or the other)
* tried to give the type that represents a row in the main table a better name (renamed from EncounterOrder to PresciptionsTableRow... I'm not in love with that one yet, but it seemed like an improvement)

Hope to do some more refactoring next week, but this was the start!