### PR TITLE
remove drug header

### DIFF
--- a/src/forms/dispense-form.component.tsx
+++ b/src/forms/dispense-form.component.tsx
@@ -195,7 +195,7 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
       {isLoading && <DataTableSkeleton role="progressbar" />}
       <div className={styles.formWrapper}>
         <section className={styles.formGroup}>
-          <span style={{ marginTop: "1rem" }}>1. {t("drug", "Drug")}</span>
+          {/* <span style={{ marginTop: "1rem" }}>1. {t("drug", "Drug")}</span>*/}
           <FormLabel>
             {t(
               "drugHelpText",


### PR DESCRIPTION
Just a tiny PR here... we are starting to demo to stakeholders and there was a request from the BAs to remove/hide the "1. Drug" header until we implement the "2. Internal Comments" header because it was confusing to have a "1" without a "2".